### PR TITLE
[WIP] Bump ruby versions in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2.0
-  - 2.3.0
-  - 2.4.0
+  - 2.5.1
+  - 2.4.4
+  - 2.3.7
 before_install: gem install bundler -v 1.14.6


### PR DESCRIPTION
* [x] CI する ruby version を https://www.ruby-lang.org/ja/downloads/ のサポート版にする
* [ ] .rubocop.yml の TargetRubyVersion を .travis.yml に書かれた一番古い `2.3` にする